### PR TITLE
ツールチップの実装方法を更新し、D3.js、Chart.js、ApexChartsにおける具体的な設定例を追加。moonbeam使用時の`…

### DIFF
--- a/.github/agents/development-helper-agent.md
+++ b/.github/agents/development-helper-agent.md
@@ -250,12 +250,49 @@ var formattedValue = chart.formatNumber(value, '#,###');
 
 ### 5.2 ツールチップの実装
 
+**重要**: `tdgtitle`属性はWebFOCUSの標準チャートエンジン（moonbeam）で描画された要素でのみ有効です。D3.js、Chart.js、ApexChartsなどのサードパーティライブラリを使用する場合は、それぞれのライブラリ固有のツールチップ実装方法を使用してください。
+
+#### moonbeamを使用する場合（標準チャート）
 ```javascript
 // ツールチップコンテンツの設定
 element.setAttribute('tdgtitle', tooltipContent);
 
 // またはモジュールを使用
 renderConfig.modules.tooltip.updateToolTips();
+```
+
+#### D3.jsを使用する場合
+```javascript
+// SVG title要素を使用（ブラウザ標準ツールチップ）
+element.append('title')
+  .text(tooltipContent);
+
+// またはtooltipモジュールのautoContentを使用
+modules: {
+  tooltip: {
+    supported: true,
+    autoContent: function(target, s, g, d) {
+      return d.labels + ': ' + d.value;
+    }
+  }
+}
+```
+
+#### Chart.js/ApexChartsを使用する場合
+各ライブラリのオプションでツールチップを設定：
+```javascript
+// Chart.jsの場合
+options: {
+  plugins: {
+    tooltip: {
+      callbacks: {
+        label: function(context) {
+          return context.label + ': ' + context.parsed.y;
+        }
+      }
+    }
+  }
+}
 ```
 
 ### 5.3 データ選択の有効化
@@ -286,7 +323,7 @@ var color = chart.getSeriesAndGroupProperty(seriesID, groupID, 'color');
 | `extensionManager is not defined` | tdgchart.jsが読み込まれていない | test.htmlでのスクリプト読み込み順序を確認 |
 | `Cannot read property 'data'` | renderConfigが不正 | renderCallbackの引数を確認 |
 | 描画されない | コンテナへの要素追加漏れ | renderConfig.containerへの追加を確認 |
-| ツールチップが表示されない | tdgtitle属性の設定漏れ | 要素に`tdgtitle`属性を設定 |
+| ツールチップが表示されない | tdgtitle属性の設定漏れ（moonbeam使用時）またはライブラリ固有のツールチップ設定漏れ | moonbeam使用時は要素に`tdgtitle`属性を設定、D3.js使用時はSVG `title`要素、Chart.js使用時はoptions.tooltipを設定 |
 
 ### 6.2 デバッグ手順
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -258,12 +258,49 @@ var formattedValue = chart.formatNumber(value, '#,###');
 
 ### 5.2 ツールチップの実装
 
+**重要**: `tdgtitle`属性はWebFOCUSの標準チャートエンジン（moonbeam）で描画された要素でのみ有効です。D3.js、Chart.js、ApexChartsなどのサードパーティライブラリを使用する場合は、それぞれのライブラリ固有のツールチップ実装方法を使用してください。
+
+#### moonbeamを使用する場合（標準チャート）
 ```javascript
 // ツールチップコンテンツの設定
 element.setAttribute('tdgtitle', tooltipContent);
 
 // またはモジュールを使用
 renderConfig.modules.tooltip.updateToolTips();
+```
+
+#### D3.jsを使用する場合
+```javascript
+// SVG title要素を使用（ブラウザ標準ツールチップ）
+element.append('title')
+  .text(tooltipContent);
+
+// またはtooltipモジュールのautoContentを使用
+modules: {
+  tooltip: {
+    supported: true,
+    autoContent: function(target, s, g, d) {
+      return d.labels + ': ' + d.value;
+    }
+  }
+}
+```
+
+#### Chart.js/ApexChartsを使用する場合
+各ライブラリのオプションでツールチップを設定：
+```javascript
+// Chart.jsの場合
+options: {
+  plugins: {
+    tooltip: {
+      callbacks: {
+        label: function(context) {
+          return context.label + ': ' + context.parsed.y;
+        }
+      }
+    }
+  }
+}
 ```
 
 ### 5.3 データ選択の有効化
@@ -294,7 +331,7 @@ var color = chart.getSeriesAndGroupProperty(seriesID, groupID, 'color');
 | `extensionManager is not defined` | tdgchart.jsが読み込まれていない | test.htmlでのスクリプト読み込み順序を確認 |
 | `Cannot read property 'data'` | renderConfigが不正 | renderCallbackの引数を確認 |
 | 描画されない | コンテナへの要素追加漏れ | renderConfig.containerへの追加を確認 |
-| ツールチップが表示されない | tdgtitle属性の設定漏れ | 要素に`tdgtitle`属性を設定 |
+| ツールチップが表示されない | tdgtitle属性の設定漏れ（moonbeam使用時）またはライブラリ固有のツールチップ設定漏れ | moonbeam使用時は要素に`tdgtitle`属性を設定、D3.js使用時はSVG `title`要素、Chart.js使用時はoptions.tooltipを設定 |
 
 ### 6.2 デバッグ手順
 

--- a/com.shimokado.d3_sample/com.shimokado.d3_sample.js
+++ b/com.shimokado.d3_sample/com.shimokado.d3_sample.js
@@ -111,8 +111,45 @@
 			.attr('fill', d => color(d.parent.data.name))
 			.attr('stroke', '#fff')
 			.attr('stroke-width', 1)
-			// ツールチップ設定
-			.attr('tdgtitle', d => `${d.data.name}: ${chart.formatNumber(d.value, '#,###')}`);
+			// ツールチップ設定（すべてのラベル、値、割合を表示）
+			.attr('tdgtitle', d => {
+				// 階層パス全体を取得
+				const path = [];
+				let current = d;
+				while (current) {
+					if (current.data.name !== 'root') {
+						path.unshift(current.data.name);
+					}
+					current = current.parent;
+				}
+				const fullLabel = path.join(' > ');
+				
+				// 値と割合
+				const value = d.value;
+				const percentage = root.value > 0 ? ((value / root.value) * 100).toFixed(1) : 0;
+				
+				return `${fullLabel}: ${chart.formatNumber(value, '#,###')} (${percentage}%)`;
+			})
+			// SVG title要素も追加（ブラウザ標準のツールチップ）
+			.append('title')
+			.text(d => {
+				// 階層パス全体を取得
+				const path = [];
+				let current = d;
+				while (current) {
+					if (current.data.name !== 'root') {
+						path.unshift(current.data.name);
+					}
+					current = current.parent;
+				}
+				const fullLabel = path.join(' > ');
+				
+				// 値と割合
+				const value = d.value;
+				const percentage = root.value > 0 ? ((value / root.value) * 100).toFixed(1) : 0;
+				
+				return `${fullLabel}: ${chart.formatNumber(value, '#,###')} (${percentage}%)`;
+			});
 
 		// ラベル
 		node.append('text')
@@ -180,7 +217,22 @@
 			tooltip: {
 				supported: true,
 				autoContent: function(target, s, g, d) {
-					return d.labels + ': ' + d.value;
+					// 階層パス全体を取得
+					const path = [];
+					let current = d;
+					while (current) {
+						if (current.data.name !== 'root') {
+							path.unshift(current.data.name);
+						}
+						current = current.parent;
+					}
+					const fullLabel = path.join(' > ');
+					
+					// 値と割合
+					const value = d.value;
+					const percentage = d.parent && d.parent.value > 0 ? ((value / d.parent.value) * 100).toFixed(1) : 0;
+					
+					return `${fullLabel}: ${chart.formatNumber(value, '#,###')} (${percentage}%)`;
 				}
 			}
 		}

--- a/development_guide/04_Tutorials.md
+++ b/development_guide/04_Tutorials.md
@@ -200,17 +200,16 @@ D3.js は強力なSVGベースのデータ可視化ライブラリです。ツ�
       .append('g')
       .attr('transform', d => `translate(${d.x0},${d.y0})`);
 
-    // 長方形
-    node.append('rect')
-      .attr('width', d => d.x1 - d.x0)
-      .attr('height', d => d.y1 - d.y0)
-      .attr('fill', d => color(d.parent.data.name))
-      .attr('stroke', '#fff')
-      .attr('stroke-width', 1)
-      // ツールチップ設定
-      .attr('tdgtitle', d => `${d.data.name}: ${chart.formatNumber(d.value, '#,###')}`);
-
-    // ラベル
+		// 長方形
+		node.append('rect')
+			.attr('width', d => d.x1 - d.x0)
+			.attr('height', d => d.y1 - d.y0)
+			.attr('fill', d => color(d.parent.data.name))
+			.attr('stroke', '#fff')
+			.attr('stroke-width', 1)
+			// D3.js固有のツールチップ設定（SVG title要素）
+			.append('title')
+			.text(d => `${d.data.name}: ${chart.formatNumber(d.value, '#,###')}`);    // ラベル
     node.append('text')
       .attr('x', 4)
       .attr('y', 14)
@@ -277,7 +276,7 @@ D3.js は強力なSVGベースのデータ可視化ライブラリです。ツ�
 - **階層構築**: `buildHierarchy` 関数でlabelsの階層をツリー構造に変換。
 - **D3.js API**: `d3.treemap()`, `d3.hierarchy()`, `d3.scaleOrdinal()` を使用。
 - **レスポンシブ**: テキストサイズを動的に調整して長方形に収まるように。
-- **WebFOCUS統合**: `tdgtitle` でツールチップ、`buildClassName` でデータ選択対応。
+- **WebFOCUS統合**: SVG `title`要素でツールチップ、`buildClassName` でデータ選択対応。
 
 ## 3. ApexCharts.js を使用した拡張グラフ
 

--- a/instructions.md
+++ b/instructions.md
@@ -163,12 +163,49 @@ var formattedValue = chart.formatNumber(value, '#,###');
 
 ### 5.2 ツールチップの実装
 
+**重要**: `tdgtitle`属性はWebFOCUSの標準チャートエンジン（moonbeam）で描画された要素でのみ有効です。D3.js、Chart.js、ApexChartsなどのサードパーティライブラリを使用する場合は、それぞれのライブラリ固有のツールチップ実装方法を使用してください。
+
+#### moonbeamを使用する場合（標準チャート）
 ```javascript
 // ツールチップコンテンツの設定
 element.setAttribute('tdgtitle', tooltipContent);
 
 // またはモジュールを使用
 renderConfig.modules.tooltip.updateToolTips();
+```
+
+#### D3.jsを使用する場合
+```javascript
+// SVG title要素を使用（ブラウザ標準ツールチップ）
+element.append('title')
+  .text(tooltipContent);
+
+// またはtooltipモジュールのautoContentを使用
+modules: {
+  tooltip: {
+    supported: true,
+    autoContent: function(target, s, g, d) {
+      return d.labels + ': ' + d.value;
+    }
+  }
+}
+```
+
+#### Chart.js/ApexChartsを使用する場合
+各ライブラリのオプションでツールチップを設定：
+```javascript
+// Chart.jsの場合
+options: {
+  plugins: {
+    tooltip: {
+      callbacks: {
+        label: function(context) {
+          return context.label + ': ' + context.parsed.y;
+        }
+      }
+    }
+  }
+}
 ```
 
 ### 5.3 データ選択の有効化
@@ -199,7 +236,7 @@ var color = chart.getSeriesAndGroupProperty(seriesID, groupID, 'color');
 | `extensionManager is not defined` | tdgchart.jsが読み込まれていない | test.htmlでのスクリプト読み込み順序を確認 |
 | `Cannot read property 'data'` | renderConfigが不正 | renderCallbackの引数を確認 |
 | 描画されない | コンテナへの要素追加漏れ | renderConfig.containerへの追加を確認 |
-| ツールチップが表示されない | tdgtitle属性の設定漏れ | 要素に`tdgtitle`属性を設定 |
+| ツールチップが表示されない | tdgtitle属性の設定漏れ（moonbeam使用時）またはライブラリ固有のツールチップ設定漏れ | moonbeam使用時は要素に`tdgtitle`属性を設定、D3.js使用時はSVG `title`要素、Chart.js使用時はoptions.tooltipを設定 |
 
 ### 6.2 デバッグ手順
 


### PR DESCRIPTION
This pull request improves the documentation and implementation of tooltips across different charting libraries (moonbeam, D3.js, Chart.js, ApexCharts) and enhances the tooltip content in D3.js-based code samples. The changes clarify the appropriate way to implement tooltips depending on the chart library used, and update both code and documentation to reflect best practices.

**Documentation updates for tooltip implementation:**

* Added clear explanations in `.github/agents/development-helper-agent.md`, `.github/copilot-instructions.md`, and `instructions.md` stating that the `tdgtitle` attribute is only effective with the moonbeam engine, and provided specific instructions and code samples for implementing tooltips in D3.js (using SVG `title`), Chart.js, and ApexCharts. [[1]](diffhunk://#diff-9a399aec0ae73532a8ac64a072c374fd955ca6e6b8309fde838c33ca4a4980d9R253-R255) [[2]](diffhunk://#diff-9a399aec0ae73532a8ac64a072c374fd955ca6e6b8309fde838c33ca4a4980d9R264-R297) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R261-R263) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R272-R305) [[5]](diffhunk://#diff-d36b6b731916d9e08726efa8f2e4780e4a8d3f587fc2ecf96bddd1252e4f5283R166-R168) [[6]](diffhunk://#diff-d36b6b731916d9e08726efa8f2e4780e4a8d3f587fc2ecf96bddd1252e4f5283R177-R210)

* Updated troubleshooting tables in the same documentation files to clarify that tooltip issues may be due to missing `tdgtitle` for moonbeam or missing library-specific tooltip configuration for other libraries. [[1]](diffhunk://#diff-9a399aec0ae73532a8ac64a072c374fd955ca6e6b8309fde838c33ca4a4980d9L289-R326) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L297-R334) [[3]](diffhunk://#diff-d36b6b731916d9e08726efa8f2e4780e4a8d3f587fc2ecf96bddd1252e4f5283L202-R239)

**D3.js code enhancements:**

* In `com.shimokado.d3_sample/com.shimokado.d3_sample.js`, improved tooltip content to display the full hierarchical path, value, and percentage, and added both the `tdgtitle` attribute and an SVG `title` element for comprehensive tooltip support.

* Enhanced the D3.js tooltip module's `autoContent` function to show the full label path, value, and percentage, making tooltips more informative.

* Updated the D3.js sample in `development_guide/04_Tutorials.md` to use the SVG `title` element for tooltips instead of the `tdgtitle` attribute, and revised documentation to reflect this change. [[1]](diffhunk://#diff-9190811eb3901c93e1c60aaad18a4af30fbfa407caa668e061f12f23cb2c9163L210-R212) [[2]](diffhunk://#diff-9190811eb3901c93e1c60aaad18a4af30fbfa407caa668e061f12f23cb2c9163L280-R279)